### PR TITLE
Allow plugin to add retina image sizes

### DIFF
--- a/high-resoloution-images-with-srcset.php
+++ b/high-resoloution-images-with-srcset.php
@@ -35,8 +35,6 @@ class HM_WP_Srcset {
 		$this->plugin_url  = plugin_dir_url( __FILE__ );
 		$this->multipliers = apply_filters( 'hm_wp_srcset', array( 2 ) );
 
-		add_image_size( 'test', 100, 100, true );
-
 		register_activation_hook( __FILE__ , array( $this, 'plugin_activation_check' ) );
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );


### PR DESCRIPTION
The plugin can register image sizes at retina versions of all the original images.

You need to define this - as we might not want WP to generate these automatically if we're using something like WP Thumb
